### PR TITLE
fix(docker-compose): use deps from image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@
         - "4000:4000"
       depends_on:
         - galactic_db
-      volumes:
-      - ./:/app/
       networks:
         - galactic_network
       


### PR DESCRIPTION
You will get a mix deps error if you mount your local volume, even though the deps are already baked into the image. This fixes that issue and allows any machine even if they are not running Elixir to run your assignment.